### PR TITLE
Resize output before calling configure

### DIFF
--- a/caffe2/mobile/contrib/opencl/operators/activation_ops.cc
+++ b/caffe2/mobile/contrib/opencl/operators/activation_ops.cc
@@ -36,6 +36,10 @@ bool CLReluOp<T>::RunOnDevice() {
     }
     relu_layer_.run();
   } else {
+    bool need_allocation = false;
+    if (Y->get_underlying() != X_->get_underlying()) {
+      need_allocation = Y->ResizeLike(*X_, true);
+    }
     // Configure
     relu_layer_.configure(
         X_->get_underlying(), Y->get_underlying(),
@@ -43,10 +47,6 @@ bool CLReluOp<T>::RunOnDevice() {
           arm_compute::ActivationLayerInfo::ActivationFunction::RELU));
     // Allocate
     X_->lazy_allocate(Xblob, second_run_, true);
-    bool need_allocation = false;
-    if (Y->get_underlying() != X_->get_underlying()) {
-      need_allocation = Y->ResizeLike(*X_, true);
-    }
     if (need_allocation) {
       Y->allocate();
     }

--- a/caffe2/mobile/contrib/opencl/operators/concat_op.cc
+++ b/caffe2/mobile/contrib/opencl/operators/concat_op.cc
@@ -91,6 +91,7 @@ bool CLConcatOp<T>::RunOnDevice() {
     Y->allocate();
     concat_layer_.run();
   } else {
+    bool need_allocation = Y->Resize(output_dims);
     // Configure
     std::vector<arm_compute::ICLTensor*> inputsTensor;
     for (int i = 0; i < inputs_.size(); ++i) {
@@ -103,7 +104,6 @@ bool CLConcatOp<T>::RunOnDevice() {
       auto* Xblob = inputsBlob[i];
       X->lazy_allocate(Xblob, second_run_, true);
     }
-    bool need_allocation = Y->Resize(output_dims);
     if (need_allocation) {
       Y->allocate();
     }

--- a/caffe2/mobile/contrib/opencl/operators/conv_op.cc
+++ b/caffe2/mobile/contrib/opencl/operators/conv_op.cc
@@ -196,6 +196,12 @@ bool CLConvOp<T, Activation>::RunOnDevice() {
       LOG(ERROR) << "[C2DEBUG] second after conv_.run()";
     }
   } else {
+    TensorCPU fakeX;
+    fakeX.Resize(X_->dims());
+    TensorCPU fakeY;
+    ConvPoolOpBase<CLContext>::SetOutputSize(fakeX, &fakeY, filter_->dim32(0));
+    LOG(ERROR) << "[C2DEBUG] after SetOutputSize";
+    bool need_allocation = Y->ResizeLike(fakeY, true);
     // Configure
     if (depthwise) {
       depth_conv_.configure(X_->get_underlying(), filter_->get_underlying(), bias_->get_underlying(),
@@ -227,13 +233,6 @@ bool CLConvOp<T, Activation>::RunOnDevice() {
     X_->lazy_allocate(Xblob, second_run_, true);
     filter_->lazy_allocate(filterblob, second_run_, true);
     bias_->lazy_allocate(biasblob, second_run_, true);
-    LOG(ERROR) << "[C2DEBUG] after X";
-    TensorCPU fakeX;
-    fakeX.Resize(X_->dims());
-    TensorCPU fakeY;
-    ConvPoolOpBase<CLContext>::SetOutputSize(fakeX, &fakeY, filter_->dim32(0));
-    LOG(ERROR) << "[C2DEBUG] after SetOutputSize";
-    bool need_allocation = Y->ResizeLike(fakeY, true);
     if (need_allocation) {
       LOG(ERROR) << "[C2DEBUG] Y->allocate() in third run.";
       Y->allocate();

--- a/caffe2/mobile/contrib/opencl/operators/conv_transpose_op.cc
+++ b/caffe2/mobile/contrib/opencl/operators/conv_transpose_op.cc
@@ -124,6 +124,11 @@ bool CLConvTransposeOp<T>::RunOnDevice() {
 
     conv_trans_.run();
   } else {
+    TensorCPU fakeX;
+    fakeX.Resize(X_->dims());
+    TensorCPU fakeY;
+    ConvTransposeUnpoolBase<CLContext>::SetOutputSize(fakeX, &fakeY, output_channels);
+    bool need_allocation = Y->ResizeLike(fakeY, true);
     // Configure
     conv_trans_.configure(
                     X_->get_underlying(), refilter_.get_underlying(), bias_->get_underlying(),
@@ -132,11 +137,6 @@ bool CLConvTransposeOp<T>::RunOnDevice() {
                     arm_compute::WeightsInfo(false, 0, 0, 0, true /* retain weights from previous run */));
     // Allocate
     X_->lazy_allocate(Xblob, second_run_, true);
-    TensorCPU fakeX;
-    fakeX.Resize(X_->dims());
-    TensorCPU fakeY;
-    ConvTransposeUnpoolBase<CLContext>::SetOutputSize(fakeX, &fakeY, output_channels);
-    bool need_allocation = Y->ResizeLike(fakeY, true);
     if (need_allocation) {
       Y->allocate();
     }

--- a/caffe2/mobile/contrib/opencl/operators/elementwise_sum_op.cc
+++ b/caffe2/mobile/contrib/opencl/operators/elementwise_sum_op.cc
@@ -40,12 +40,12 @@ bool CLSumOp<T>::RunOnDevice() {
     Y->allocate();
     add_layer_.run();
   } else {
+    bool need_allocation = Y->ResizeLike(*A_);
     // Configure
     add_layer_.configure(A_->get_underlying(), B_->get_underlying(), Y->get_underlying(), arm_compute::ConvertPolicy::SATURATE);
     // Allocate
     A_->lazy_allocate(Ablob, second_run_, true);
     B_->lazy_allocate(Bblob, second_run_, true);
-    bool need_allocation = Y->ResizeLike(*A_);
     if (need_allocation) {
       Y->allocate();
     }

--- a/caffe2/mobile/contrib/opencl/operators/fully_connected_op.cc
+++ b/caffe2/mobile/contrib/opencl/operators/fully_connected_op.cc
@@ -58,12 +58,12 @@ bool CLFullyConnectedOp<T>::RunOnDevice() {
     Y->allocate();
     fc_layer_.run();
   } else {
+    bool need_allocation = Y->Resize(output_dims);
     // Configure
     fc_layer_.configure(X_->get_underlying(), W_->get_underlying(),
                      B_->get_underlying(), Y->get_underlying(), true, false, true);
     // Allocate
     X_->lazy_allocate(Xblob, second_run_, true);
-    bool need_allocation = Y->Resize(output_dims);
     if (need_allocation) {
       Y->allocate();
     }

--- a/caffe2/mobile/contrib/opencl/operators/pool_op.cc
+++ b/caffe2/mobile/contrib/opencl/operators/pool_op.cc
@@ -85,6 +85,7 @@ bool CLAveragePoolOp<DataType>::RunOnDeviceWithOrderNCHW() {
     Y->allocate();
     pooling_layer_.run();
   } else {
+    bool need_allocation =Y->Resize(output_dims);
     // Configure
     if (global_pooling_) {
       arm_compute::PoolingLayerInfo info(arm_compute::PoolingType::AVG);
@@ -99,7 +100,6 @@ bool CLAveragePoolOp<DataType>::RunOnDeviceWithOrderNCHW() {
     }
     // Allocate
     X_->lazy_allocate(Xblob, second_run_, true);
-    bool need_allocation =Y->Resize(output_dims);
     if (need_allocation) {
       Y->allocate();
     }
@@ -151,6 +151,7 @@ template <> bool CLMaxPoolOp<DataType>::RunOnDeviceWithOrderNCHW() {
     Y->allocate();
     pooling_layer_.run();
   } else {
+    bool need_allocation = Y->Resize(output_dims);
     // Configure
     if (global_pooling_) {
       arm_compute::PoolingLayerInfo info(arm_compute::PoolingType::MAX);
@@ -165,7 +166,6 @@ template <> bool CLMaxPoolOp<DataType>::RunOnDeviceWithOrderNCHW() {
     }
     // Allocate
     X_->lazy_allocate(Xblob, second_run_, true);
-    bool need_allocation = Y->Resize(output_dims);
     if (need_allocation) {
       Y->allocate();
     }

--- a/caffe2/mobile/contrib/opencl/operators/resize_op.cc
+++ b/caffe2/mobile/contrib/opencl/operators/resize_op.cc
@@ -58,11 +58,11 @@ bool CLResizeNearestOp<T>::RunOnDevice() {
     Y->allocate();
     resize_layer_.run();
   } else {
+    bool need_allocation = Y->Resize(output_dims);
     // Configure
     resize_layer_.configure(X_->get_underlying(), Y->get_underlying(), arm_compute::InterpolationPolicy::NEAREST_NEIGHBOR, arm_compute::BorderMode::UNDEFINED);
     // Allocate
     X_->lazy_allocate(Xblob, second_run_, true);
-    bool need_allocation = Y->Resize(output_dims);
     if (need_allocation) {
       Y->allocate();
     }

--- a/caffe2/mobile/contrib/opencl/operators/softmax_op.cc
+++ b/caffe2/mobile/contrib/opencl/operators/softmax_op.cc
@@ -37,11 +37,11 @@ bool CLSoftmaxOp<T>::RunOnDevice() {
     Y->allocate();
     softmax_layer_.run();
   } else {
+    bool need_allocation = Y->ResizeLike(*X_);
     // Configure
     softmax_layer_.configure(X_->get_underlying(), Y->get_underlying());
     // Allocate
     X_->lazy_allocate(Xblob, second_run_, true);
-    bool need_allocation = Y->ResizeLike(*X_);
     if (need_allocation) {
       Y->allocate();
     }

--- a/caffe2/mobile/contrib/opencl/operators/spatial_batch_norm_op.cc
+++ b/caffe2/mobile/contrib/opencl/operators/spatial_batch_norm_op.cc
@@ -76,13 +76,13 @@ bool CLSpatialBNOp<T>::RunOnDevice() {
     Y->allocate();
     bn_layer_.run();
   } else {
+    bool need_allocation = Y->ResizeLike(*X_);
     // Configure
     bn_layer_.configure(X_->get_underlying(), Y->get_underlying(),
                      mean_->get_underlying(), var_->get_underlying(),
                      bias_->get_underlying(), scale_->get_underlying(), epsilon_);
     // Allocate
     X_->lazy_allocate(XBlob, second_run_, true);
-    bool need_allocation = Y->ResizeLike(*X_);
     if (need_allocation) {
       Y->allocate();
     }


### PR DESCRIPTION
Resizing should happen before configure, otherwise the configuration might be done using wrong shapes.